### PR TITLE
extracted task metadata to TaskDecorator

### DIFF
--- a/work-tracker-core/pom.xml
+++ b/work-tracker-core/pom.xml
@@ -59,6 +59,12 @@ limitations under the License.
             <artifactId>logback-classic</artifactId>
             <version>${ch.qos.logback.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.2</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/work-tracker-core/src/main/java/com/deere/isg/worktracker/ContextualExecutor.java
+++ b/work-tracker-core/src/main/java/com/deere/isg/worktracker/ContextualExecutor.java
@@ -14,41 +14,35 @@
  * limitations under the License.
  */
 
-
 package com.deere.isg.worktracker;
 
-import com.deere.clock.Clock;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.Executor;
 
 import static java.util.Collections.emptyMap;
-import static net.logstash.logback.argument.StructuredArguments.kv;
 
 public class ContextualExecutor implements Executor {
-    public static final String TASK_TIME_INTERVAL = Work.TIME_INTERVAL;
-    public static final String TASK_ELAPSED_MS = Work.ELAPSED_MS;
-    public static final String TASK_ID = "task_id";
-    public static final String TASK_CLASS_NAME = "task_class_name";
-
-    private Logger logger = LoggerFactory.getLogger(ContextualExecutor.class);
+    protected final ContextualTaskDecorator taskDecorator;
     private Executor executor;
 
     public ContextualExecutor(Executor executor) {
+        this(executor, new ContextualTaskDecorator());
+    }
+
+    public ContextualExecutor(Executor executor, ContextualTaskDecorator taskDecorator) {
         this.executor = executor;
+        this.taskDecorator = taskDecorator;
     }
 
     @Override
     public void execute(Runnable runnable) {
         Map<String, String> parentMdc = cleanseParentMdc();
-        executor.execute(() -> wrap(parentMdc, runnable));
+        executor.execute(taskDecorator.decorate(parentMdc, runnable));
     }
 
     protected Map<String, String> cleanseParentMdc() {
@@ -77,52 +71,6 @@ public class ContextualExecutor implements Executor {
     }
 
     protected void setLogger(Logger logger) {
-        this.logger = logger;
-    }
-
-    protected void wrap(Map<String, String> parentMdc, Runnable runnable) {
-        long startTime = nowInMillis();
-        try {
-            beforeExecute(parentMdc, getClassName(runnable));
-            runnable.run();
-        } finally {
-            afterExecute(startTime);
-        }
-    }
-
-    protected final void beforeExecute(Map<String, String> parentMdc, String className) {
-        Optional.ofNullable(parentMdc).orElse(emptyMap()).forEach(MDC::put);
-        addMetadataToMDC(className);
-        taskStart();
-    }
-
-    protected final void afterExecute(long startTime) {
-        taskEnd(nowInMillis() - startTime);
-        MDC.clear();
-    }
-
-    protected long nowInMillis() {
-        return Clock.milliseconds();
-    }
-
-    protected String getClassName(Object object) {
-        return object != null ? object.getClass().getName() : null;
-    }
-
-    private void taskStart() {
-        logger.info("Task started", kv(TASK_TIME_INTERVAL, "start"));
-    }
-
-    private void taskEnd(long elapsedMillis) {
-        logger.info("Task ended after {} ms", kv(TASK_ELAPSED_MS, elapsedMillis), kv(TASK_TIME_INTERVAL, "end"));
-    }
-
-    private void addMetadataToMDC(String className) {
-        MDC.put(TASK_ID, UUID.randomUUID().toString());
-
-        if (className != null) {
-            MDC.put(TASK_CLASS_NAME, className);
-        }
-
+        taskDecorator.setLogger(logger);
     }
 }

--- a/work-tracker-core/src/main/java/com/deere/isg/worktracker/ContextualTaskDecorator.java
+++ b/work-tracker-core/src/main/java/com/deere/isg/worktracker/ContextualTaskDecorator.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2018 Deere & Company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.deere.isg.worktracker;
+
+import com.deere.clock.Clock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+import static java.util.Collections.emptyMap;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+public class ContextualTaskDecorator {
+    public static final String TASK_TIME_INTERVAL = Work.TIME_INTERVAL;
+    public static final String TASK_ELAPSED_MS = Work.ELAPSED_MS;
+    public static final String TASK_ID = "task_id";
+    public static final String TASK_CLASS_NAME = "task_class_name";
+    private Logger logger = LoggerFactory.getLogger(ContextualTaskDecorator.class);
+
+    public Runnable decorate(Map<String, String> parentMdc, Runnable runnable) {
+        return () -> {
+            long startTime = nowInMillis();
+            try {
+                beforeExecute(parentMdc, getClassName(runnable));
+                runnable.run();
+            } finally {
+                afterExecute(startTime);
+            }
+        };
+    }
+
+    public <T> Callable<T> decorate(Map<String, String> parentMdc, Callable<T> task) {
+        return () -> {
+            long startTime = nowInMillis();
+            try {
+                beforeExecute(parentMdc, getClassName(task));
+                return task.call();
+            } finally {
+                afterExecute(startTime);
+            }
+        };
+
+    }
+
+    protected void setLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    protected final void beforeExecute(Map<String, String> parentMdc, String className) {
+        Optional.ofNullable(parentMdc).orElse(emptyMap()).forEach(MDC::put);
+        addMetadataToMDC(className);
+        taskStart();
+    }
+
+    protected final void afterExecute(long startTime) {
+        taskEnd(nowInMillis() - startTime);
+        MDC.clear();
+    }
+
+    protected String getClassName(Object object) {
+        return object != null ? object.getClass().getName() : null;
+    }
+
+    private void taskStart() {
+        logger.info("Task started", kv(TASK_TIME_INTERVAL, "start"));
+    }
+
+    private void taskEnd(long elapsedMillis) {
+        logger.info("Task ended after {} ms", kv(TASK_ELAPSED_MS, elapsedMillis), kv(TASK_TIME_INTERVAL, "end"));
+    }
+
+    private void addMetadataToMDC(String className) {
+        MDC.put(TASK_ID, UUID.randomUUID().toString());
+
+        if (className != null) {
+            MDC.put(TASK_CLASS_NAME, className);
+        }
+
+    }
+
+    private long nowInMillis() {
+        return Clock.milliseconds();
+    }
+}

--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/ContextualExecutorServiceTest.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/ContextualExecutorServiceTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2018 Deere & Company
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,8 @@
 
 package com.deere.isg.worktracker;
 
+import com.deere.isg.worktracker.ExecutorTestUtils.MockCallable;
+import com.deere.isg.worktracker.ExecutorTestUtils.MockTask;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -26,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static com.deere.isg.worktracker.ExecutorTestUtils.UUID_PATTERN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;

--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/ContextualExecutorTest.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/ContextualExecutorTest.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.deere.isg.worktracker;
 
 import net.logstash.logback.marker.SingleFieldAppendingMarker;
@@ -30,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static com.deere.isg.worktracker.ExecutorTestUtils.UUID_PATTERN;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/ContextualTaskDecoratorTest.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/ContextualTaskDecoratorTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2018 Deere & Company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.deere.isg.worktracker;
+
+import com.deere.isg.worktracker.ExecutorTestUtils.MockCallable;
+import com.deere.isg.worktracker.ExecutorTestUtils.MockRunnable;
+import net.logstash.logback.marker.SingleFieldAppendingMarker;
+import org.hamcrest.CustomMatcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.slf4j.Logger;
+import org.slf4j.MDC;
+
+import java.util.regex.Pattern;
+
+import static com.deere.isg.worktracker.ExecutorTestUtils.UUID_PATTERN;
+import static java.util.Collections.emptyMap;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ContextualTaskDecoratorTest {
+    private static final String TASK_CLASS_NAME = "task_class_name";
+    private static final String TASK_ID = "task_id";
+    private static final String TEST_KEY = "testKey";
+    private static final String TEST_VALUE = "testValue";
+    private MockRunnable runnable;
+    private ContextualTaskDecorator taskDecorator;
+    private MockCallable callable;
+    private Logger logger;
+
+    @Before
+    public void setUp() {
+        MDC.clear();
+        taskDecorator = new ContextualTaskDecorator();
+        callable = new MockCallable();
+        runnable = new MockRunnable();
+        logger = mock(Logger.class);
+    }
+
+    @After
+    public void tearDown() {
+        runnable.reset();
+        callable.reset();
+        MDC.clear();
+    }
+
+    @Test
+    public void verifyStartAndEndLogsForRunnable() {
+        ArgumentCaptor<SingleFieldAppendingMarker> timeCapture = ArgumentCaptor
+                .forClass(SingleFieldAppendingMarker.class);
+
+        taskDecorator.setLogger(logger);
+        taskDecorator.decorate(emptyMap(), runnable).run();
+        boolean uuidMatch = UUID_PATTERN.matcher(runnable.getValue(TASK_ID)).matches();
+
+        verify(logger).info("Task started", kv("time_interval", "start"));
+
+        verify(logger).info(ArgumentMatchers.startsWith("Task ended after {} ms"), timeCapture.capture(), eq(kv("time_interval", "end")));
+        assertThat(timeCapture.getValue().getFieldName(), is("elapsed_ms"));
+        assertThat(timeCapture.getValue().toString(), matches(".*(\\d{4}).*"));
+        assertThat(uuidMatch, is(true));
+        assertThat(runnable.getValue(TASK_CLASS_NAME), containsString("MockRunnable"));
+    }
+
+    @Test
+    public void verifyStartAndEndLogsForCallable() {
+        ArgumentCaptor<SingleFieldAppendingMarker> timeCapture = ArgumentCaptor
+                .forClass(SingleFieldAppendingMarker.class);
+
+        taskDecorator.setLogger(logger);
+        taskDecorator.decorate(emptyMap(), runnable).run();
+        boolean uuidMatch = UUID_PATTERN.matcher(runnable.getValue(TASK_ID)).matches();
+
+        verify(logger).info("Task started", kv("time_interval", "start"));
+
+        verify(logger).info(ArgumentMatchers.startsWith("Task ended after {} ms"), timeCapture.capture(), eq(kv("time_interval", "end")));
+        assertThat(timeCapture.getValue().getFieldName(), is("elapsed_ms"));
+        assertThat(timeCapture.getValue().toString(), matches(".*(\\d{4}).*"));
+        assertThat(uuidMatch, is(true));
+        assertThat(runnable.getValue(TASK_CLASS_NAME), containsString("MockRunnable"));
+    }
+
+    @Test
+    public void hasParentMdcRunnable() {
+        MDC.put(TEST_KEY, TEST_VALUE);
+        taskDecorator.decorate(emptyMap(), runnable).run();
+
+
+        assertThat(runnable.getValue(TEST_KEY), is(TEST_VALUE));
+    }
+
+    @Test
+    public void hasParentMdcCallable() throws Exception {
+        MDC.put(TEST_KEY, TEST_VALUE);
+        taskDecorator.decorate(emptyMap(), callable).call();
+
+        assertThat(callable.getValue(TEST_KEY), is(TEST_VALUE));
+    }
+
+    private CustomMatcher<String> matches(String regex) {
+        return new CustomMatcher<String>(regex) {
+            @Override
+            public boolean matches(Object item) {
+                return Pattern.compile(regex)
+                        .matcher((String) item)
+                        .matches();
+            }
+        };
+    }
+}

--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/ExecutorTestHelper.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/ExecutorTestHelper.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2018 Deere & Company
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,22 +17,16 @@
 package com.deere.isg.worktracker;
 
 import com.deere.clock.Clock;
+import com.deere.isg.worktracker.ExecutorTestUtils.MockRunnable;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.regex.Pattern;
 
-import static com.deere.isg.worktracker.ContextualExecutor.TASK_ID;
 import static org.mockito.Mockito.mock;
 
 class ExecutorTestHelper {
-    protected static final Pattern UUID_PATTERN =
-            Pattern.compile("^[a-zA-Z0-9]{8}-([a-zA-Z0-9]{4}-){3}[a-zA-Z0-9]{12}$");
     protected ExecutorService executorService;
     protected MockRunnable runnable;
     protected Logger logger;
@@ -69,49 +63,6 @@ class ExecutorTestHelper {
         }
         MDC.clear();
         Clock.clear();
-
-    }
-
-    class MockTask {
-        protected Logger actualLogger = LoggerFactory.getLogger(MockTask.class);
-        protected Map<String, String> mdcCopy;
-
-        public String getValue(String key) {
-            return mdcCopy.get(key);
-        }
-
-        public void reset() {
-            mdcCopy = null;
-        }
-    }
-
-    class MockRunnable extends MockTask implements Runnable {
-        @Override
-        public void run() {
-            mdcCopy = MDC.getCopyOfContextMap();
-            actualLogger.debug(MDC.get(TASK_ID));
-            Clock.freeze(Clock.now().plus(1000));
-        }
-    }
-
-    class MockCallable extends MockTask implements Callable<String> {
-        private final String output;
-
-        MockCallable() {
-            this("test");
-        }
-
-        MockCallable(String output) {
-            this.output = output;
-        }
-
-        @Override
-        public String call() throws Exception {
-            mdcCopy = MDC.getCopyOfContextMap();
-            actualLogger.debug(MDC.get(TASK_ID));
-            Clock.freeze(Clock.now().plus(1000));
-            return output;
-        }
 
     }
 }

--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/ExecutorTestUtils.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/ExecutorTestUtils.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2018 Deere & Company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.deere.isg.worktracker;
+
+import com.deere.clock.Clock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
+
+import static com.deere.isg.worktracker.ContextualTaskDecorator.TASK_ID;
+
+public final class ExecutorTestUtils {
+    static final Pattern UUID_PATTERN =
+            Pattern.compile("^[a-zA-Z0-9]{8}-([a-zA-Z0-9]{4}-){3}[a-zA-Z0-9]{12}$");
+
+    private ExecutorTestUtils() {
+
+    }
+
+    static class MockTask {
+        protected Logger actualLogger = LoggerFactory.getLogger(MockTask.class);
+        protected Map<String, String> mdcCopy;
+
+        public String getValue(String key) {
+            return mdcCopy.get(key);
+        }
+
+        public void reset() {
+            mdcCopy = null;
+        }
+    }
+
+    static class MockRunnable extends MockTask implements Runnable {
+        @Override
+        public void run() {
+            mdcCopy = MDC.getCopyOfContextMap();
+            actualLogger.debug(MDC.get(TASK_ID));
+            Clock.freeze(Clock.now().plus(1000));
+        }
+    }
+
+    static class MockCallable extends MockTask implements Callable<String> {
+        private final String output;
+
+        MockCallable() {
+            this("test");
+        }
+
+        MockCallable(String output) {
+            this.output = output;
+        }
+
+        @Override
+        public String call() throws Exception {
+            mdcCopy = MDC.getCopyOfContextMap();
+            actualLogger.debug(MDC.get(TASK_ID));
+            Clock.freeze(Clock.now().plus(1000));
+            return output;
+        }
+
+    }
+}

--- a/work-tracker-spring/src/main/java/com/deere/isg/worktracker/spring/PathMetadataCleanser.java
+++ b/work-tracker-spring/src/main/java/com/deere/isg/worktracker/spring/PathMetadataCleanser.java
@@ -17,7 +17,7 @@
 
 package com.deere.isg.worktracker.spring;
 
-import com.deere.isg.worktracker.ContextualExecutor;
+import com.deere.isg.worktracker.ContextualTaskDecorator;
 import com.deere.isg.worktracker.Work;
 import com.deere.isg.worktracker.servlet.HttpWork;
 
@@ -89,8 +89,8 @@ public class PathMetadataCleanser implements KeyCleanser {
                 HttpWork.SESSION_ID,
                 HttpWork.PATH,
                 HttpWork.ACCEPT,
-                ContextualExecutor.TASK_CLASS_NAME,
-                ContextualExecutor.TASK_ID,
+                ContextualTaskDecorator.TASK_CLASS_NAME,
+                ContextualTaskDecorator.TASK_ID,
                 SpringWork.ENDPOINT,
                 ID,
                 UNDERSCORE_ID,


### PR DESCRIPTION
This will allow apps to use the decorator pattern for adding task start and end for spring's scheduledTaskExecutor. This can also be used with the [TaskDecorator](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/task/SimpleAsyncTaskExecutor.html#setTaskDecorator-org.springframework.core.task.TaskDecorator-) provided by Spring

- [x] I have followed the [Contribution Guidelines](../blob/master/.github/CONTTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (Has passed ```mvn clean verify``` locally.)
- [ ] pom.xml version follows the [Semantic Versioning](https://semver.org/) rules.
- [ ] I have updated the documentation as necessary.
- [x] I have added myself to the [Contributors File](../blob/master/CONTRIBUTORS.md).
- [x] I know all contributors must sign the Contributor License Agreement.
