### PR TITLE
Fix the Task end messages.

### DIFF
--- a/work-tracker-core/src/main/java/com/deere/isg/worktracker/OutstandingTaskDecorator.java
+++ b/work-tracker-core/src/main/java/com/deere/isg/worktracker/OutstandingTaskDecorator.java
@@ -76,7 +76,8 @@ public class OutstandingTaskDecorator<W extends TaskWork> implements TaskDecorat
 
     private void doEndLog(W payload) {
         List<StructuredArgument> endInfo = payload != null ? payload.getEndInfo() : new ArrayList<>();
-        logger.info("Task ended: {1} {"+endInfo.size()+"}", endInfo.toArray());
+        String successMessage = (payload != null && payload.isSuccess()) ? "Successful" : "Failure";
+        logger.info("Task ended: {} "+ successMessage, endInfo.toArray());
     }
 
     /**

--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/OutstandingTaskDecoratorTest.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/OutstandingTaskDecoratorTest.java
@@ -79,7 +79,7 @@ public class OutstandingTaskDecoratorTest {
         verify(logger).info(eq("Task started"), anyObject(),
                 eq(kv("zombie", false)), eq(kv("time_interval", "start")));
 
-        verify(logger).info(ArgumentMatchers.startsWith("Task ended: {1} {3}"),
+        verify(logger).info(ArgumentMatchers.startsWith("Task ended: {} Failure"),
                 timeCapture.capture(), eq(kv("zombie", false)),
                 eq(kv("time_interval", "end")));
 
@@ -101,7 +101,7 @@ public class OutstandingTaskDecoratorTest {
         verify(logger).info(eq("Task started"), anyObject(),
                 eq(kv("zombie", false)), eq(kv("time_interval", "start")));
 
-        verify(logger).info(ArgumentMatchers.startsWith("Task ended: {1} {3}"),
+        verify(logger).info(ArgumentMatchers.startsWith("Task ended: {} Failure"),
                 timeCapture.capture(), eq(kv("zombie", false)),
                 eq(kv("time_interval", "end")));
         assertThat(timeCapture.getValue().getFieldName(), is("elapsed_ms"));


### PR DESCRIPTION
They were printing the numbers instead of looking up which keyValue to print.

- [x] I have followed the [Contribution Guidelines](../blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (Has passed ```mvn clean verify``` locally.)
- [x] pom.xml version follows the [Semantic Versioning](https://semver.org/) rules.
- [x] I have updated the documentation as necessary.
- [x] I have added myself to the [Contributors File](../blob/master/CONTRIBUTORS.md).
- [x] I know all contributors must sign the Contributor License Agreement.
