### PR TITLE
Fix backwards compatibility. OutstandingWorkTracker should be Iterable

### DIFF
--- a/work-tracker-core/src/main/java/com/deere/isg/worktracker/OutstandingWorkFilter.java
+++ b/work-tracker-core/src/main/java/com/deere/isg/worktracker/OutstandingWorkFilter.java
@@ -18,6 +18,7 @@ package com.deere.isg.worktracker;
 
 import com.deere.isg.outstanding.Outstanding;
 
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -55,5 +56,10 @@ public class OutstandingWorkFilter<W extends Work> implements OutstandingWorkTra
     @Override
     public void doInTransaction(W payload, Runnable transaction) {
         parent.doInTransaction(payload, transaction);
+    }
+
+    @Override
+    public Iterator<W> iterator() {
+        return stream().iterator();
     }
 }

--- a/work-tracker-core/src/main/java/com/deere/isg/worktracker/OutstandingWorkTracker.java
+++ b/work-tracker-core/src/main/java/com/deere/isg/worktracker/OutstandingWorkTracker.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public interface OutstandingWorkTracker<W extends Work> {
+public interface OutstandingWorkTracker<W extends Work> extends Iterable<W> {
     Stream<W> stream();
     Optional<W> current();
     Outstanding<W>.Ticket create(W payload);

--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/OutstandingWorkFilterTest.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/OutstandingWorkFilterTest.java
@@ -18,8 +18,12 @@ package com.deere.isg.worktracker;
 
 import org.junit.Test;
 
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -73,5 +77,34 @@ public class OutstandingWorkFilterTest {
         filtered.doInTransaction(payload, ()->{
             assertThat(filtered.current().orElseGet(null), is(payload));
         });
+    }
+
+    @Test
+    public void iterable() {
+        base.doInTransaction(new SuperWork(), ()->{
+            final Iterator<TestWork> iterator = filtered.iterator();
+            assertThat(iterator.hasNext(), is(false));
+            assertNoSuchElement(iterator);
+        });
+        base.doInTransaction(new AnotherWork(), ()->{
+            final Iterator<TestWork> iterator = filtered.iterator();
+            assertThat(iterator.hasNext(), is(false));
+            assertNoSuchElement(iterator);
+        });
+        TestWork work = new TestWork();
+        base.doInTransaction(work, ()->{
+            final Iterator<TestWork> iterator = filtered.iterator();
+            assertThat(iterator.hasNext(), is(true));
+            assertThat(iterator.next(), is(work));
+        });
+    }
+
+    private void assertNoSuchElement(Iterator<?> iterator) {
+        try {
+            iterator.next();
+            fail("Should have thrown exception");
+        } catch(NoSuchElementException e) {
+            // expected
+        }
     }
 }


### PR DESCRIPTION

- [x] I have followed the [Contribution Guidelines](../blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (Has passed ```mvn clean verify``` locally.)
- [x] pom.xml version follows the [Semantic Versioning](https://semver.org/) rules.
- [x] I have updated the documentation as necessary.
- [x] I have added myself to the [Contributors File](../blob/master/CONTRIBUTORS.md).
- [x] I know all contributors must sign the Contributor License Agreement.
