### PR TITLE
fix: Tickets can no longer get leaked if threads never get new work.

### DIFF
--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/OutstandingWorkTest.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/OutstandingWorkTest.java
@@ -17,14 +17,22 @@
 package com.deere.isg.worktracker;
 
 import com.deere.clock.Clock;
+import com.deere.isg.outstanding.Outstanding;
 import net.logstash.logback.argument.StructuredArgument;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.MDC;
 
 import java.io.IOException;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
 import static org.hamcrest.CoreMatchers.*;
@@ -88,6 +96,44 @@ public class OutstandingWorkTest {
                 () -> assertThat(outstanding.current().orElseThrow(AssertionError::new), is(work)));
 
         assertThat(outstanding.current().isPresent(), is(false));
+    }
+
+    @Test
+    public void ticketsAreNotLeakedByThreadLocal() throws InterruptedException, ExecutionException {
+        final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+
+        try {
+            final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+            // First, we need a ticket created on some thread that will reference tickets made later
+            outstanding.create(new MockWork()).close();
+            // Now get a ticket on another thread
+            final WeakReference<Outstanding<?>.Ticket> ref = executorService.submit(() -> {
+                System.out.println("I'm creating the weak reference");
+                outstanding.createTicket(new MockWork()).close();
+                final WeakReference<Outstanding<?>.Ticket> ticketToReferTo = new WeakReference<>(
+                        outstanding.create(new MockWork()), queue);
+                // we need some other ticket created that may be referenced as current on that other thread
+                // to remove the ticket we want to test from being referenced there.
+                outstanding.createTicket(new MockWork()).close();
+                return ticketToReferTo;
+            }).get();
+            // Now close the ticket so that it isn't referenced from the head of OutstandingWork.
+            ref.get().close();
+            // Iterating through the list cleans out any stray references to the ticket we want to make sure is gc'ed
+            outstanding.stream().forEach(System.out::println);
+
+            // now let's create a bunch of garbage so the gc will actually run
+            executorService.scheduleAtFixedRate(() -> {
+                System.out.println("I'm running the garbage");
+                outstanding.doInTransaction(new MockWork(), ()->outstanding.stream().forEach(System.out::println));
+                Runtime.getRuntime().gc();
+            }, 0, 100, TimeUnit.MILLISECONDS);
+
+            assertThat(outstanding.current().isPresent(), is(false));
+            assertThat(queue.remove(20000), CoreMatchers.is(ref));
+        } finally {
+            executorService.shutdown();
+        }
     }
 
     @Test(expected = IOException.class)

--- a/work-tracker-core/src/test/java/com/deere/isg/worktracker/OutstandingWorkTest.java
+++ b/work-tracker-core/src/test/java/com/deere/isg/worktracker/OutstandingWorkTest.java
@@ -80,6 +80,16 @@ public class OutstandingWorkTest {
                 () -> assertCurrentThread(outstanding, work));
     }
 
+    @Test
+    public void currentIsSetWhileInTransactionAndClearedWhenDone() {
+        MockWork work = new MockWork();
+
+        outstanding.doInTransactionChecked(work,
+                () -> assertThat(outstanding.current().orElseThrow(AssertionError::new), is(work)));
+
+        assertThat(outstanding.current().isPresent(), is(false));
+    }
+
     @Test(expected = IOException.class)
     public void doInTransactionCheckThrowsException() throws IOException {
         outstanding.doInTransactionChecked(null, () -> {


### PR DESCRIPTION
Tickets always have a reference to the next ticket, so they are unsafe to include in a ThreadLocal that may not ever get cleared.

- [X] I have followed the [Contribution Guidelines](../blob/master/.github/CONTRIBUTING.md).
- [X] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed. (Has passed ```mvn clean verify``` locally.)
- [X] pom.xml version follows the [Semantic Versioning](https://semver.org/) rules.
- [X] I have updated the documentation as necessary.
- [X] I have added myself to the [Contributors File](../blob/master/CONTRIBUTORS.md).
- [X] I know all contributors must sign the Contributor License Agreement.
